### PR TITLE
fix: add target _blank to about us links

### DIFF
--- a/about.html
+++ b/about.html
@@ -74,10 +74,10 @@
                         If you would like to explore other areas of mindfullness and meditation or you perhaps want to find out more about mental health services, we have included some
                         other sites below.
                         <ul class="resource-links">
-                            <li><a href="https://www.mind.org.uk/" class="resource-link-title">Mind</a> - provide support and raise awareness about mental health.</li>
-                            <li><a href="https://www.thecalmzone.net/" class="resource-link-title">Campaign Against Living Miserably(CALM)</a> - take a stand against suicide and provide support.</li>
-                            <li><a href="https://www.mindful.org/" class="resource-link-title">Mindful</a> - provide lots of information about mindfulness and meditation.</li>
-                            <li><a href="https://www.nhs.uk/mental-health/" class="resource-link-title">NHS</a> - provide information and support for a variety of topics related to mental health.</li>
+                            <li><a href="https://www.mind.org.uk/" target="_blank" class="resource-link-title">Mind</a> - provide support and raise awareness about mental health.</li>
+                            <li><a href="https://www.thecalmzone.net/" target="_blank" class="resource-link-title">Campaign Against Living Miserably(CALM)</a> - take a stand against suicide and provide support.</li>
+                            <li><a href="https://www.mindful.org/" target="_blank" class="resource-link-title">Mindful</a> - provide lots of information about mindfulness and meditation.</li>
+                            <li><a href="https://www.nhs.uk/mental-health/" target="_blank" class="resource-link-title">NHS</a> - provide information and support for a variety of topics related to mental health.</li>
                         </ul>
                         
                     </p>

--- a/templates/about.html
+++ b/templates/about.html
@@ -74,10 +74,10 @@
                         If you would like to explore other areas of mindfullness and meditation or you perhaps want to find out more about mental health services, we have included some
                         other sites below.
                         <ul class="resource-links">
-                            <li><a href="https://www.mind.org.uk/" class="resource-link-title">Mind</a> - provide support and raise awareness about mental health.</li>
-                            <li><a href="https://www.thecalmzone.net/" class="resource-link-title">Campaign Against Living Miserably(CALM)</a> - take a stand against suicide and provide support.</li>
-                            <li><a href="https://www.mindful.org/" class="resource-link-title">Mindful</a> - provide lots of information about mindfulness and meditation.</li>
-                            <li><a href="https://www.nhs.uk/mental-health/" class="resource-link-title">NHS</a> - provide information and support for a variety of topics related to mental health.</li>
+                            <li><a href="https://www.mind.org.uk/" target="_blank" class="resource-link-title">Mind</a> - provide support and raise awareness about mental health.</li>
+                            <li><a href="https://www.thecalmzone.net/" target="_blank" class="resource-link-title">Campaign Against Living Miserably(CALM)</a> - take a stand against suicide and provide support.</li>
+                            <li><a href="https://www.mindful.org/" target="_blank" class="resource-link-title">Mindful</a> - provide lots of information about mindfulness and meditation.</li>
+                            <li><a href="https://www.nhs.uk/mental-health/" target="_blank" class="resource-link-title">NHS</a> - provide information and support for a variety of topics related to mental health.</li>
                         </ul>
                         
                     </p>


### PR DESCRIPTION
Added target="_blank" to the hyperlinks in the about us so the user will still be on our site where a new tab opens instead of being redirected to the linked site.